### PR TITLE
Remove status category overrides

### DIFF
--- a/api/config.ts
+++ b/api/config.ts
@@ -9,8 +9,6 @@ export type Callbacks<T, Collection = T[]> = {
   beforeSave?: (records: Collection, repo: Repository<T>) => void;
 };
 
-export type IssueCallbacks = Callbacks<Issue, IssueCollection>;
-
 export type MetricsConfig = {
   jira: {
     host: string;
@@ -23,7 +21,7 @@ export type MetricsConfig = {
   sync: {
     statuses?: Callbacks<Status>;
     fields?: Callbacks<Field>;
-    issues?: IssueCallbacks;
+    issues?: Callbacks<Issue, IssueCollection>;
   };
 };
 

--- a/api/routers/actions/sync_action.ts
+++ b/api/routers/actions/sync_action.ts
@@ -69,20 +69,6 @@ export async function syncIssues(): Promise<Array<Issue>> {
   }
   await issuesRepo.save(issues);
 
-  const statusCategoryOverrides = {};
-  if (process.env.STATUS_CATEGORY_OVERRIDES) {
-    (process.env.STATUS_CATEGORY_OVERRIDES || "")
-      .split(",")
-      .forEach((override) => {
-        const [key, statusCategory] = override.split("=");
-        statusCategoryOverrides[key] = statusCategory;
-        console.log(`statusCategory override: ${key} = ${statusCategory}`);
-        issueCollection.getIssue(key).statusCategory = statusCategory;
-      });
-
-    await issuesRepo.save(issues);
-  }
-
   if (process.env.EPIC_CYCLE_TIME_STRATEGY === "STORIES") {
     console.log(
       "EPIC_CYCLE_TIME_STRATEGY = STORIES, computing epic cycle times..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
       - EPIC_CYCLE_TIME_EXCL_RESOLUTIONS
       - EPIC_CYCLE_TIME_DONE_TIMEOUT_STATUS
       - EPIC_CYCLE_TIME_DONE_TIMEOUT
-      - STATUS_CATEGORY_OVERRIDES
 
     command: npm run debug
     depends_on:


### PR DESCRIPTION
The STATUS_CATEGORY_OVERRIDES option was used for statuses missing from the Jira API, but the statuses.beforeSave hook can now be used to create missing statuses so there's no longer a need for this functionality.